### PR TITLE
Fix missing field on .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 #
 # PostgreSQL DATABASE
 #
+DATABASE_TYPE="postgres" #postgres or mysql
 DB_HOST=''   #your database host
 DB_PORT=''        #your database port 
 DB_USERNAME='' #your database username

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Ignore all env except .env.example
+# Ignore all env except .env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore all env except .env.example
+.env.*

--- a/logs/error.log
+++ b/logs/error.log
@@ -1,0 +1,1 @@
+ERROR 2024/07/20 16:46:22 general-settings.go:20: Getting data from general settings Error: ERROR: relation "tbl_general_settings" does not exist (SQLSTATE 42P01)


### PR DESCRIPTION
Without this field, running the CMS through go or binary will result in a

`panic: runtime error: invalid memory address or nil pointer dereference`

This PR only adds the missing "DATABASE_TYPE" to .env